### PR TITLE
Fix bug where not parsing reserverID

### DIFF
--- a/app/src/main/java/com/a0xffffffff/dinesum/FirebaseManager.java
+++ b/app/src/main/java/com/a0xffffffff/dinesum/FirebaseManager.java
@@ -284,6 +284,7 @@ public class FirebaseManager {
     public Request parseJson(DataSnapshot requestSnapshot) {
         String requestID = (String) requestSnapshot.child("requestID").getValue();
         String requesterID = (String) requestSnapshot.child("requesterID").getValue();
+        String reserverID = (String) requestSnapshot.child("reserverID").getValue();
         String state = (String) requestSnapshot.child("requestState").getValue();
 
         // request info
@@ -309,6 +310,7 @@ public class FirebaseManager {
         RequestData newRequestData = new RequestData(startTime, endTime, partyName, numParty,
                 restaurant, payment, creationDate);
         Request newRequest = new Request(requesterID, newRequestData, requestID);
+        newRequest.setReserverID(reserverID);
         newRequest.setRequestState(state);
 
         return newRequest;

--- a/app/src/main/java/com/a0xffffffff/dinesum/Request.java
+++ b/app/src/main/java/com/a0xffffffff/dinesum/Request.java
@@ -33,6 +33,7 @@ public class Request {
         mRequesterID = requesterID;
         mRequestState = RequestState.PENDING;
         mRequestData = requestData;
+        mReserverID = "";
     }
 
     /**
@@ -46,6 +47,7 @@ public class Request {
         mRequesterID = requesterID;
         mRequestState = RequestState.PENDING;
         mRequestData = requestData;
+        mReserverID = "";
     }
 
     public String getRequestID() {


### PR DESCRIPTION
IMPORTANT: Didn't actually implement user rating yet.

Fixed the bug where reserverID is not getting parsed. Thus, even though we can filter requests by reserverID initially, after "completed" requests are rewritten to database, the reserverID is not written. This makes it so that "completed" requests no longer contain the correct reserverID in Firebase and cannot be displayed.

To make sure that we can parse reserverID correctly in FirebaseManager.parseJson(), we initialize reserverID to empty string initially instead leaving it as null.